### PR TITLE
Censor singles from background_exc

### DIFF
--- a/bin/all_sky_search/pycbc_add_statmap
+++ b/bin/all_sky_search/pycbc_add_statmap
@@ -427,6 +427,7 @@ for f_in in files:
     combo_repeat_bg = np.array(np.repeat(key.encode('utf8'),
                                f_in['background/stat'].size))
     bg_coinc_type = np.concatenate([bg_coinc_type, combo_repeat_bg])
+
 # Apply previously used clustering
 fg_coinc_type = fg_coinc_type[cidx]
 
@@ -436,9 +437,9 @@ sep_fg_data = {}
 sep_bg_data = {}
 final_fg_data = {}
 for combo in all_ifo_combos:
-    idx_fg_ct = np.nonzero(fg_coinc_type == combo.encode('utf8'))
+    idx_fg_ct = np.flatnonzero(fg_coinc_type == combo.encode('utf8'))
     sep_fg_data[combo] = combined_fg_data.select(idx_fg_ct)
-    idx_bg_ct = np.nonzero(bg_coinc_type == combo.encode('utf8'))
+    idx_bg_ct = np.flatnonzero(bg_coinc_type == combo.encode('utf8'))
     sep_bg_data[combo] = combined_bg_data.select(idx_bg_ct)
     final_fg_data[combo] = pycbc.io.DictArray(
         data={k: np.array([], sep_fg_data[combo].data[k].dtype)

--- a/bin/all_sky_search/pycbc_add_statmap
+++ b/bin/all_sky_search/pycbc_add_statmap
@@ -160,14 +160,15 @@ if not injection_style:
         if k not in all_ifos:
             pycbc.io.combine_and_copy(f, files, 'background_exc/' + k)
 
+# create dataset of ifo combination strings
+fg_coinc_type = np.array([])
+for f_in in files:
+    key = get_ifo_string(f_in).replace(' ','')
+    combo_repeat = np.array(np.repeat(key.encode('utf8'),
+                            f_in['foreground/stat'].size))
+    fg_coinc_type = np.concatenate([fg_coinc_type, combo_repeat])
+
 if args.output_coinc_types:
-    # create dataset of ifo combination strings
-    fg_coinc_type = np.array([])
-    for f_in in files:
-        key = get_ifo_string(f_in).replace(' ','')
-        combo_repeat = np.array(np.repeat(key.encode('utf8'),
-                                f_in['foreground/fap'].size))
-        fg_coinc_type = np.concatenate([fg_coinc_type, combo_repeat])
     f['foreground/ifo_combination'] = fg_coinc_type
 
 logging.info('Collating triggers into single structure')
@@ -271,6 +272,7 @@ for key in f['foreground'].keys():
         for k in f['foreground/%s' % key].keys():
             filter_dataset(f, 'foreground/{}/{}'.format(key, k), cidx)
 
+fg_coinc_type = fg_coinc_type[cidx]
 n_triggers = f['foreground/stat'].size
 
 logging.info('Calculating event times to determine which types of coinc '
@@ -301,8 +303,6 @@ far = {}
 far_exc = {}
 bg_time = {}
 bg_time_exc = {}
-fnlouder = {}
-fnlouder_exc = {}
 
 if injection_style:
     # if background files are provided, this is being used for injections
@@ -310,40 +310,40 @@ if injection_style:
     for bg_fname in args.background_files:
         bg_f = h5py.File(bg_fname, 'r')
         ifo_combo_key = bg_f.attrs['ifos'].replace(' ','')
-        _, fnlouder[ifo_combo_key] = \
-            significance.get_n_louder(
+        _, far[ifo_combo_key] = significance.get_far(
                 bg_f['background/stat'][:],
                 f['foreground/stat'][:],
                 bg_f['background/decimation_factor'][:],
+                bg_f.attrs['background_time'],
                 **significance_dict[ifo_combo_key])
 
-        far[ifo_combo_key] = (fnlouder[ifo_combo_key] + 1) / bg_f.attrs['background_time']
-        _, fnlouder_exc[ifo_combo_key] = \
-            significance.get_n_louder(
+        _, far_exc[ifo_combo_key] = \
+            significance.get_far(
                 bg_f['background_exc/stat'][:],
                 f['foreground/stat'][:],
                 bg_f['background_exc/decimation_factor'][:],
+                bg_f.attrs['background_time_exc'],
                 **significance_dict[ifo_combo_key])
-        far_exc[ifo_combo_key] = (fnlouder_exc[ifo_combo_key] + 1) / bg_f.attrs['background_time_exc']
 else:
     # if not injection style input files, then the input files will have the
     # background included
     for f_in in files:
         ifo_combo_key = get_ifo_string(f_in).replace(' ','')
-        _, fnlouder[ifo_combo_key] = \
-            significance.get_n_louder(
+        _, far[ifo_combo_key] = \
+            significance.get_far(
                 f_in['background/stat'][:],
                 f['foreground/stat'][:],
                 f_in['background/decimation_factor'][:],
+                f_in.attrs['background_time'],
                 **significance_dict[ifo_combo_key])
-        far[ifo_combo_key] = (fnlouder[ifo_combo_key] + 1) / f_in.attrs['background_time']
-        _, fnlouder_exc[ifo_combo_key] = \
-            significance.get_n_louder(
+
+        _, far_exc[ifo_combo_key] = \
+            significance.get_far(
                 f_in['background_exc/stat'][:],
                 f['foreground/stat'][:],
                 f_in['background_exc/decimation_factor'][:],
+                f_in.attrs['background_time_exc'],
                 **significance_dict[ifo_combo_key])
-        far_exc[ifo_combo_key] = (fnlouder_exc[ifo_combo_key] + 1) / f_in.attrs['background_time_exc']
 
 logging.info('Combining false alarm rates from all available backgrounds')
 
@@ -357,8 +357,15 @@ fg_fars = np.array([list(far[ct]) for ct in all_ifo_combos])
 fg_fars_exc = np.array([list(far_exc[ct]) for ct in all_ifo_combos])
 
 # Combine the FARs with the mask to obtain the new ifars
-fg_ifar = conv.sec_to_year(1. / np.sum(isincombo_mask * fg_fars, axis=0))
-fg_ifar_exc = conv.sec_to_year(1. / np.sum(isincombo_mask * fg_fars_exc, axis=0))
+fg_fars_out = np.sum(isincombo_mask * fg_fars, axis=0)
+fg_fars_exc_out = np.sum(isincombo_mask * fg_fars_exc, axis=0)
+
+# Apply any limits as appropriate
+fg_fars_out = significance.apply_far_limit(fg_fars_out, significance_dict, combo=fg_coinc_type)
+fg_fars_exc_out = significance.apply_far_limit(fg_fars_exc_out, significance_dict, combo=fg_coinc_type)
+
+fg_ifar = conv.sec_to_year(1. / fg_fars_out)
+fg_ifar_exc = conv.sec_to_year(1. / fg_fars_exc_out)
 fg_time = f.attrs['foreground_time']
 del isincombo_mask, fg_fars, fg_fars_exc, _
 
@@ -415,7 +422,7 @@ bg_coinc_type = np.array([])
 for f_in in files:
     key = get_ifo_string(f_in).replace(' ','')
     combo_repeat_fg = np.array(np.repeat(key.encode('utf8'),
-                               f_in['foreground/fap'].size))
+                               f_in['foreground/stat'].size))
     fg_coinc_type = np.concatenate([fg_coinc_type, combo_repeat_fg])
     combo_repeat_bg = np.array(np.repeat(key.encode('utf8'),
                                f_in['background/stat'].size))
@@ -587,29 +594,30 @@ while True:
     test_times = np.array([pycbc.events.mean_if_greater_than_zero(tc)[0]
                            for tc in zip(*times_tuple)])
     for key in all_ifo_combos:
-        bnlouder, fnlouder = significance.get_n_louder(
-            sep_bg_data[key].data['stat'],
-            sep_fg_data[key].data['stat'],
-            sep_bg_data[key].data['decimation_factor'],
-            **significance_dict[ifo_combo_key])
         # In principle, bg time should be adjusted, but is expected to be a
         # negligible correction
         fg_time_ct[key] -= args.cluster_window
         bg_t_y = conv.sec_to_year(bg_time_ct[key])
         fg_t_y = conv.sec_to_year(fg_time_ct[key])
-        sep_bg_data[key].data['ifar'] = bg_t_y / (bnlouder + 1)
-        sep_fg_data[key].data['ifar'] = bg_t_y / (fnlouder + 1)
+        bg_far, fg_far = significance.get_far(
+            sep_bg_data[key].data['stat'],
+            sep_fg_data[key].data['stat'],
+            sep_bg_data[key].data['decimation_factor'],
+            bg_t_y,
+            **significance_dict[ifo_combo_key])
+        sep_bg_data[key].data['ifar'] = 1. / bg_far
+        sep_fg_data[key].data['ifar'] = 1. / fg_far
         sep_fg_data[key].data['fap'] = 1 - \
-            np.exp(-fg_t_y / sep_fg_data[key].data['ifar'])
+            np.exp(-fg_t_y * fg_far)
 
     logging.info("Recalculating combined IFARs")
     for key in all_ifo_combos:
-        bnlouder, fnlouder = significance.get_n_louder(
+        _, far[key] = significance.get_far(
             sep_bg_data[key].data['stat'],
             combined_fg_data.data['stat'],
             sep_bg_data[key].data['decimation_factor'],
+            bg_time_ct[key],
             **significance_dict[ifo_combo_key])
-        far[key] = (fnlouder + 1) / bg_time_ct[key]
         # Set up variable for whether each coincidence is available in each coincidence time
         is_in_combo_time[key] = np.zeros(n_triggers)
         end_times = np.array(f['segments/%s/end' % key][:])

--- a/bin/all_sky_search/pycbc_add_statmap
+++ b/bin/all_sky_search/pycbc_add_statmap
@@ -427,7 +427,6 @@ for f_in in files:
     combo_repeat_bg = np.array(np.repeat(key.encode('utf8'),
                                f_in['background/stat'].size))
     bg_coinc_type = np.concatenate([bg_coinc_type, combo_repeat_bg])
-
 # Apply previously used clustering
 fg_coinc_type = fg_coinc_type[cidx]
 
@@ -437,9 +436,9 @@ sep_fg_data = {}
 sep_bg_data = {}
 final_fg_data = {}
 for combo in all_ifo_combos:
-    idx_fg_ct = np.flatnonzero(fg_coinc_type == combo.encode('utf8'))
+    idx_fg_ct = np.nonzero(fg_coinc_type == combo.encode('utf8'))
     sep_fg_data[combo] = combined_fg_data.select(idx_fg_ct)
-    idx_bg_ct = np.flatnonzero(bg_coinc_type == combo.encode('utf8'))
+    idx_bg_ct = np.nonzero(bg_coinc_type == combo.encode('utf8'))
     sep_bg_data[combo] = combined_bg_data.select(idx_bg_ct)
     final_fg_data[combo] = pycbc.io.DictArray(
         data={k: np.array([], sep_fg_data[combo].data[k].dtype)

--- a/bin/all_sky_search/pycbc_coinc_statmap
+++ b/bin/all_sky_search/pycbc_coinc_statmap
@@ -48,6 +48,12 @@ parser.add_argument('--cluster-window', type=float, default=10,
 parser.add_argument('--veto-window', type=float, default=.1,
                     help='Time around each zerolag trigger to window out '
                          '[default=.1s]')
+parser.add_argument('--hierarchical-removal-ifar-threshold',
+                    type=float, default=0.5,
+                    help="Threshold to remove foreground triggers with "
+                         "IFAR (years) above this value from the exclusive "
+                         "background, and for hierarchical removal "
+                         "[default=0.5yr]")
 parser.add_argument('--hierarchical-removal-window', type=float, default=1.0,
                     help='Time around each trigger to window out for a very '
                          'louder trigger in the hierarchical removal '
@@ -307,21 +313,21 @@ orig_fore_stat = fore_stat
 if args.max_hierarchical_removal != 0:
     # If user wants to remove against inclusive background.
     if args.hierarchical_removal_against == 'inclusive':
-        ifar_foreground = ifar
+        ifar_foreground_yrs = conv.sec_to_year(ifar)
     # Otherwise user wants to remove against exclusive background
     else :
-        ifar_foreground = ifar_exc
+        ifar_foreground_yrs = conv.sec_to_year(ifar_exc)
 else :
-    # It doesn't matter if you choose ifar_foreground = ifar
+    # It doesn't matter if you choose ifar_foreground_yrs is from ifar
     # or ifar_exc, the while loop below will break
     # straight away. But this avoids a NameError
-    ifar_foreground = ifar
+    ifar_foreground_yrs = ifar
 
 # Step 2 : Loop until we don't have to hierarchically remove anymore. This
-#          will happen when ifar_foreground has no elements greater than
+#          will happen when ifar_foreground_yrs has no elements greater than
 #          the background time.
 
-while numpy.any(ifar_foreground >= background_time):
+while numpy.any(ifar_foreground_yrs >= args.hierarchical_removal_ifar_threshold):
     # If the user wants to stop doing hierarchical removals after a set
     # number of iterations then break when that happens.
     if (h_iterations == args.max_hierarchical_removal):
@@ -421,13 +427,13 @@ while numpy.any(ifar_foreground >= background_time):
         return_counts=True,
         **significance_dict[ifo_combo])
 
-    # Update the ifar_foreground criteria depending on whether foreground
+    # Update the ifar_foreground_yrs criteria depending on whether foreground
     # triggers are being removed via inclusive or exclusive background.   
     if args.hierarchical_removal_against == 'inclusive':
-        ifar_foreground = 1. / fg_far
+        ifar_foreground_yrs = 1. / fg_far
 
     # Exclusive background doesn't change when removing foreground triggers.
-    # So we don't have to take background ifar, just repopulate ifar_foreground
+    # So we don't have to take background ifar, just repopulate ifar_foreground_yrs
     else :
         _, fg_far_exc = significance.get_far(
             exc_zero_trigs.stat,
@@ -435,8 +441,8 @@ while numpy.any(ifar_foreground >= background_time):
             exc_zero_trigs.decimation_factor,
             background_time_exc,
             **significance_dict[ifo_combo])
-        ifar_foreground = 1. / fg_far_exc
-    # ifar_foreground has been updated and the code can continue.
+        ifar_foreground_yrs = 1. / fg_far_exc
+    # ifar_foreground_yrs has been updated and the code can continue.
 
     logging.info("Calculating ifar/fap values")
     f['background_h%s/ifar' % h_iterations] = conv.sec_to_year(1. / bg_far)

--- a/bin/all_sky_search/pycbc_coinc_statmap
+++ b/bin/all_sky_search/pycbc_coinc_statmap
@@ -48,12 +48,6 @@ parser.add_argument('--cluster-window', type=float, default=10,
 parser.add_argument('--veto-window', type=float, default=.1,
                     help='Time around each zerolag trigger to window out '
                          '[default=.1s]')
-parser.add_argument('--hierarchical-removal-ifar-threshold',
-                    type=float, default=0.5,
-                    help="Threshold to remove foreground triggers with "
-                         "IFAR (years) above this value from the exclusive "
-                         "background, and for hierarchical removal "
-                         "[default=0.5yr]")
 parser.add_argument('--hierarchical-removal-window', type=float, default=1.0,
                     help='Time around each trigger to window out for a very '
                          'louder trigger in the hierarchical removal '
@@ -313,21 +307,21 @@ orig_fore_stat = fore_stat
 if args.max_hierarchical_removal != 0:
     # If user wants to remove against inclusive background.
     if args.hierarchical_removal_against == 'inclusive':
-        ifar_foreground_yrs = conv.sec_to_year(ifar)
+        ifar_foreground = ifar
     # Otherwise user wants to remove against exclusive background
     else :
-        ifar_foreground_yrs = conv.sec_to_year(ifar_exc)
+        ifar_foreground = ifar_exc
 else :
-    # It doesn't matter if you choose ifar_foreground_yrs is from ifar
+    # It doesn't matter if you choose ifar_foreground = ifar
     # or ifar_exc, the while loop below will break
     # straight away. But this avoids a NameError
-    ifar_foreground_yrs = ifar
+    ifar_foreground = ifar
 
 # Step 2 : Loop until we don't have to hierarchically remove anymore. This
-#          will happen when ifar_foreground_yrs has no elements greater than
+#          will happen when ifar_foreground has no elements greater than
 #          the background time.
 
-while numpy.any(ifar_foreground_yrs >= args.hierarchical_removal_ifar_threshold):
+while numpy.any(ifar_foreground >= background_time):
     # If the user wants to stop doing hierarchical removals after a set
     # number of iterations then break when that happens.
     if (h_iterations == args.max_hierarchical_removal):
@@ -427,13 +421,13 @@ while numpy.any(ifar_foreground_yrs >= args.hierarchical_removal_ifar_threshold)
         return_counts=True,
         **significance_dict[ifo_combo])
 
-    # Update the ifar_foreground_yrs criteria depending on whether foreground
+    # Update the ifar_foreground criteria depending on whether foreground
     # triggers are being removed via inclusive or exclusive background.   
     if args.hierarchical_removal_against == 'inclusive':
-        ifar_foreground_yrs = 1. / fg_far
+        ifar_foreground = 1. / fg_far
 
     # Exclusive background doesn't change when removing foreground triggers.
-    # So we don't have to take background ifar, just repopulate ifar_foreground_yrs
+    # So we don't have to take background ifar, just repopulate ifar_foreground
     else :
         _, fg_far_exc = significance.get_far(
             exc_zero_trigs.stat,
@@ -441,8 +435,8 @@ while numpy.any(ifar_foreground_yrs >= args.hierarchical_removal_ifar_threshold)
             exc_zero_trigs.decimation_factor,
             background_time_exc,
             **significance_dict[ifo_combo])
-        ifar_foreground_yrs = 1. / fg_far_exc
-    # ifar_foreground_yrs has been updated and the code can continue.
+        ifar_foreground = 1. / fg_far_exc
+    # ifar_foreground has been updated and the code can continue.
 
     logging.info("Calculating ifar/fap values")
     f['background_h%s/ifar' % h_iterations] = conv.sec_to_year(1. / bg_far)

--- a/bin/all_sky_search/pycbc_coinc_statmap
+++ b/bin/all_sky_search/pycbc_coinc_statmap
@@ -241,23 +241,29 @@ fore_stat = all_trigs.stat[fore_locs]
 
 # Cumulative array of inclusive background triggers and the number of
 # inclusive background triggers louder than each foreground trigger
-back_cnum, fnlouder = significance.get_n_louder(
+bg_far, fg_far = significance.get_far(
     back_stat,
     fore_stat,
     all_trigs.decimation_factor[back_locs],
+    background_time,
     **significance_dict[ifo_combo])
 
 # Cumulative array of exclusive background triggers and the number
 # of exclusive background triggers louder than each foreground trigger
-back_cnum_exc, fnlouder_exc = significance.get_n_louder(
+bg_far_exc, fg_far_exc = significance.get_far(
     exc_zero_trigs.stat,
     fore_stat,
     exc_zero_trigs.decimation_factor,
+    background_time_exc,
     **significance_dict[ifo_combo])
 
-f['background/ifar'] = conv.sec_to_year(background_time / (back_cnum + 1))
-f['background_exc/ifar'] = conv.sec_to_year(background_time_exc /
-                                            (back_cnum_exc + 1))
+fg_far = significance.apply_far_limit(fg_far, significance_dict, combo=ifo_combo)
+bg_far = significance.apply_far_limit(bg_far, significance_dict, combo=ifo_combo)
+fg_far_exc = significance.apply_far_limit(fg_far_exc, significance_dict, combo=ifo_combo)
+bg_far_exc = significance.apply_far_limit(bg_far_exc, significance_dict, combo=ifo_combo)
+
+f['background/ifar'] = conv.sec_to_year(1. / bg_far)
+f['background_exc/ifar'] = conv.sec_to_year(1. / bg_far_exc)
 f.attrs['background_time'] = background_time
 f.attrs['foreground_time'] = coinc_time
 f.attrs['background_time_exc'] = background_time_exc
@@ -266,11 +272,11 @@ f.attrs['foreground_time_exc'] = coinc_time_exc
 logging.info("calculating ifar/fap values")
 
 if fore_locs.sum() > 0:
-    ifar = background_time / (fnlouder + 1)
+    ifar = 1. / fg_far
     fap = 1 - numpy.exp(- coinc_time / ifar)
     f['foreground/ifar'] = conv.sec_to_year(ifar)
     f['foreground/fap'] = fap
-    ifar_exc = background_time_exc / (fnlouder_exc + 1)
+    ifar_exc = 1. / fg_far_exc
     fap_exc = 1 - numpy.exp(- coinc_time_exc / ifar_exc)
     f['foreground/ifar_exc'] = conv.sec_to_year(ifar_exc)
     f['foreground/fap_exc'] = fap_exc
@@ -295,28 +301,27 @@ h_iterations = 0
 
 orig_fore_stat = fore_stat
 
-# Assign a new variable to keep track of whether we care about fnlouder or
-# fnlouder_exc. Whether we want to remove hierarchically against inclusive
+# Assign a new variable to keep track of whether we care about ifar or
+# ifar_exc. Whether we want to remove hierarchically against inclusive
 # or exclusive background.
 if args.max_hierarchical_removal != 0:
     # If user wants to remove against inclusive background.
     if args.hierarchical_removal_against == 'inclusive':
-        louder_foreground = fnlouder
+        ifar_foreground = ifar
     # Otherwise user wants to remove against exclusive background
     else :
-        louder_foreground = fnlouder_exc
+        ifar_foreground = ifar_exc
 else :
-    # It doesn't matter if you choose louder_foreground = fnlouder
-    # or vice versa, the while loop below will break if
-    # louder_foreground doesn't contain 0, or at the comparison
-    # h_iterations == args.max_hierarchical_removal. But this avoids
-    # a NameError
-    louder_foreground = fnlouder
+    # It doesn't matter if you choose ifar_foreground = ifar
+    # or ifar_exc, the while loop below will break
+    # straight away. But this avoids a NameError
+    ifar_foreground = ifar
 
 # Step 2 : Loop until we don't have to hierarchically remove anymore. This
-#          will happen when fnlouder has no elements that equal 0.
+#          will happen when ifar_foreground has no elements greater than
+#          the background time.
 
-while numpy.any(louder_foreground == 0):
+while numpy.any(ifar_foreground >= background_time):
     # If the user wants to stop doing hierarchical removals after a set
     # number of iterations then break when that happens.
     if (h_iterations == args.max_hierarchical_removal):
@@ -326,7 +331,7 @@ while numpy.any(louder_foreground == 0):
     # downstream codes.
     if h_iterations == 0:
         f['background_h%s/stat' % h_iterations] = back_stat
-        f['background_h%s/ifar' % h_iterations] = conv.sec_to_year(background_time / (back_cnum + 1))
+        f['background_h%s/ifar' % h_iterations] = conv.sec_to_year(1. / bg_far)
         f['background_h%s/timeslide_id' % h_iterations] = all_trigs.data['timeslide_id'][back_locs]
         f['foreground_h%s/stat' % h_iterations] = fore_stat
         f['foreground_h%s/ifar' % h_iterations] = conv.sec_to_year(ifar)
@@ -408,30 +413,33 @@ while numpy.any(louder_foreground == 0):
     logging.info("Calculating FAN from background statistic values")
     back_stat = all_trigs.stat[back_locs]
     fore_stat = all_trigs.stat[fore_locs]
-    back_cnum, fnlouder = significance.get_n_louder(
+    bg_far, fg_far = significance.get_far(
         back_stat,
         fore_stat,
         all_trigs.decimation_factor[back_locs],
+        background_time,
+        return_counts=True,
         **significance_dict[ifo_combo])
 
-    # Update the louder_foreground criteria depending on whether foreground
+    # Update the ifar_foreground criteria depending on whether foreground
     # triggers are being removed via inclusive or exclusive background.   
     if args.hierarchical_removal_against == 'inclusive':
-        louder_foreground = fnlouder
+        ifar_foreground = 1. / fg_far
 
     # Exclusive background doesn't change when removing foreground triggers.
-    # So we don't have to take back_cnum_exc, just repopulate fnlouder_exc
+    # So we don't have to take background ifar, just repopulate ifar_foreground
     else :
-        _, fnlouder_exc = significance.get_n_louder(
+        _, fg_far_exc = significance.get_far(
             exc_zero_trigs.stat,
             fore_stat,
             exc_zero_trigs.decimation_factor,
+            background_time_exc,
             **significance_dict[ifo_combo])
-        louder_foreground = fnlouder_exc
-    # louder_foreground has been updated and the code can continue.
+        ifar_foreground = 1. / fg_far_exc
+    # ifar_foreground has been updated and the code can continue.
 
     logging.info("Calculating ifar/fap values")
-    f['background_h%s/ifar' % h_iterations] = conv.sec_to_year(background_time / (back_cnum + 1))
+    f['background_h%s/ifar' % h_iterations] = conv.sec_to_year(1. / bg_far)
     f.attrs['background_time_h%s' % h_iterations] = background_time
     f.attrs['foreground_time_h%s' % h_iterations] = coinc_time
 
@@ -439,7 +447,7 @@ while numpy.any(louder_foreground == 0):
         # Write ranking statistic to file just for downstream plotting code
         f['foreground_h%s/stat' % h_iterations] = fore_stat
 
-        ifar = background_time / (fnlouder + 1)
+        ifar = 1. / fg_far
         fap = 1 - numpy.exp(- coinc_time / ifar)
         f['foreground_h%s/ifar' % h_iterations] = conv.sec_to_year(ifar)
         f['foreground_h%s/fap' % h_iterations] = fap

--- a/bin/all_sky_search/pycbc_coinc_statmap_inj
+++ b/bin/all_sky_search/pycbc_coinc_statmap_inj
@@ -83,13 +83,16 @@ f.attrs['foreground_time'] = coinc_time
 
 if len(zdata) > 0:
 
-    _, fnlouder_exc = significance.get_n_louder(
+    _, fg_far_exc = significance.get_far(
         back_stat,
         zdata.stat,
         dec_fac,
+        background_time,
         **significance_dict[ifo_key])
 
-    ifar_exc = background_time / (fnlouder_exc + 1)
+    fg_far_exc = significance.apply_far_limit(fg_far_exc, significance_dict, combo=ifo_key)
+
+    ifar_exc = 1. / fg_far_exc
     fap_exc = 1 - numpy.exp(- coinc_time / ifar_exc)
     f['foreground/ifar_exc'] = conv.sec_to_year(ifar_exc)
     f['foreground/fap_exc'] = fap_exc

--- a/bin/all_sky_search/pycbc_exclude_zerolag
+++ b/bin/all_sky_search/pycbc_exclude_zerolag
@@ -94,21 +94,24 @@ for k in filtered_trigs.data:
     f_out['background_exc/%s' % k] = filtered_trigs.data[k]
 
 logging.info('Recalculating IFARs')
-bnlouder, fnlouder = significance.get_n_louder(
+bg_far, fg_far = significance.get_far(
     filtered_trigs.data['stat'],
     f_in['foreground/stat'][:],
     filtered_trigs.data['decimation_factor'],
+    f_in.attrs['background_time_exc'],
     **significance_dict[all_ifo_key])
-# In principle exc background time should be recalculated
-# However we expect exclude zerolag to be a (very) small correction
-fg_time_exc = conv.sec_to_year(f_in.attrs['foreground_time_exc'])
-bg_time_exc = conv.sec_to_year(f_in.attrs['background_time_exc'])
-fg_ifar_exc = bg_time_exc / (fnlouder + 1)
-bg_ifar_exc = bg_time_exc / (bnlouder + 1)
+
+fg_far = significance.apply_far_limit(fg_far, significance_dict, combo=all_ifo_key)
+bg_far = significance.apply_far_limit(bg_far, significance_dict, combo=all_ifo_key)
+
+fg_ifar_exc = 1. / fg_far
+bg_ifar_exc = 1. / bg_far
 
 logging.info('Writing updated ifars to file')
-f_out['foreground/ifar_exc'][:] = fg_ifar_exc
+f_out['foreground/ifar_exc'][:] = conv.sec_to_year(fg_ifar_exc)
+f_out['background_exc/ifar'][:] = conv.sec_to_year(bg_ifar_exc)
+
+fg_time_exc = conv.sec_to_year(f_in.attrs['foreground_time_exc'])
 f_out['foreground/fap_exc'][:] = 1 - np.exp(-fg_time_exc / fg_ifar_exc)
-f_out['background_exc/ifar'][:] = bg_ifar_exc
 
 logging.info("Done!")

--- a/bin/all_sky_search/pycbc_sngls_statmap
+++ b/bin/all_sky_search/pycbc_sngls_statmap
@@ -69,11 +69,6 @@ parser.add_argument('--hierarchical-removal-against', type=str,
                          'triggers that are louder than either the "inclusive"'
                          ' (little-dogs-in) background, or the "exclusive" '
                          '(little-dogs-out) background. [default="none"]')
-parser.add_argument('--hierarchical-removal-ifar-thresh', type=float,
-                    default=100,
-                    help="Minimum IFAR for a foreground event to be "
-                         "hierarchically removed from background of quieter "
-                         "events (years) [default=100yr]")
 parser.add_argument('--output-file')
 args = parser.parse_args()
 
@@ -118,7 +113,6 @@ fg_time = float(all_trigs.attrs['foreground_time'])
 exc_veto_time = (len(back_locs) - len(back_locs)) * args.veto_window
 fg_time_exc = fg_time - exc_veto_time
 
-
 logging.info("Dumping foreground triggers")
 f = fw(args.output_file)
 f.attrs['num_of_ifos'] = 1
@@ -152,24 +146,31 @@ significance_dict = significance.digest_significance_options([ifo], args)
 
 # Cumulative array of inclusive background triggers and the number of
 # inclusive background triggers louder than each foreground trigger
-back_cnum, fnlouder = significance.get_n_louder(
+bg_far, fg_far = significance.get_far(
     back_stat,
     fore_stat,
     bkg_dec_facs,
+    fg_time,
     **significance_dict[ifo])
 
 # Cumulative array of exclusive background triggers and the number
 # of exclusive background triggers louder than each foreground trigger
-back_cnum_exc, fnlouder_exc = significance.get_n_louder(
+bg_far_exc, fg_far_exc = significance.get_far(
     back_stat_exc,
     fore_stat,
     bkg_exc_dec_facs,
+    fg_time_exc,
     **significance_dict[ifo])
 
-bg_ifar = fg_time / (back_cnum + 1)
-fg_ifar = fg_time_exc / (fnlouder + 1)
-bg_ifar_exc = fg_time / (back_cnum_exc + 1)
-fg_ifar_exc = fg_time_exc / (fnlouder_exc + 1)
+fg_far = significance.apply_far_limit(fg_far, significance_dict, combo=ifo)
+bg_far = significance.apply_far_limit(bg_far, significance_dict, combo=ifo)
+fg_far_exc = significance.apply_far_limit(fg_far_exc, significance_dict, combo=ifo)
+bg_far_exc = significance.apply_far_limit(bg_far_exc, significance_dict, combo=ifo)
+
+bg_ifar = 1. / bg_far
+fg_ifar = 1. / fg_far
+bg_ifar_exc = 1. / bg_far_exc
+fg_ifar_exc = 1. / fg_far_exc
 
 f['background/ifar'] = conv.sec_to_year(bg_ifar)
 f['background_exc/ifar'] = conv.sec_to_year(bg_ifar_exc)
@@ -222,7 +223,8 @@ else :
     ifar_louder = fg_ifar
 
 # Step 2 : Loop until we don't have to hierarchically remove anymore. This
-#          will happen when fnlouder has no elements that equal 0.
+#          will happen when ifar_louder has no elements that are
+#          less than 1 per live time, or a set maximum.
 
 while numpy.any(ifar_louder >= fg_time):
     # If the user wants to stop doing hierarchical removals after a set
@@ -300,14 +302,15 @@ while numpy.any(ifar_louder >= fg_time):
     back_stat = all_trigs.stat[back_locs]
     fore_stat = all_trigs.stat[fore_locs]
 
-    back_cnum, fnlouder = significance.get_n_louder(
+    bg_far, fg_far = significance.get_far(
         back_stat,
         fore_stat,
         numpy.ones_like(back_stat),
+        fg_time,
         **significance_dict[ifo])
 
-    bg_ifar = fg_time / (back_cnum + 1)
-    fg_ifar = fg_time / (fnlouder + 1)
+    bg_ifar = 1. / bg_far
+    fg_ifar = 1. / fg_far
 
     # Update the ifar_louder criteria depending on whether foreground
     # triggers are being removed via inclusive or exclusive background.
@@ -315,15 +318,16 @@ while numpy.any(ifar_louder >= fg_time):
         ifar_louder = fg_ifar
 
     # Exclusive background doesn't change when removing foreground triggers.
-    # So we don't have to take back_cnum_exc, just repopulate fg_ifar_exc
+    # So we don't have to take bg_far_exc, just repopulate fg_ifar_exc
     else:
-        _, fnlouder_exc = significance.get_n_louder(
+        _, fg_far_exc = significance.get_far(
             back_stat_exc,
             fore_stat,
             numpy.ones_like(back_stat_exc),
+            fg_time_exc,
             **significance_dict[ifo])
 
-        fg_ifar_exc = fg_time / (fnlouder_exc + 1)
+        fg_ifar_exc = 1. / fg_far_exc
 
         ifar_louder = fg_ifar_exc
 

--- a/bin/all_sky_search/pycbc_sngls_statmap
+++ b/bin/all_sky_search/pycbc_sngls_statmap
@@ -190,6 +190,14 @@ while any(bg_ifar_exc > fg_time):
 
     bg_ifar_exc = 1. / bg_far_exc
     fg_ifar_exc = 1. / fg_far_exc
+    fg_far_exc = significance.apply_far_limit(
+        fg_far_exc,
+        significance_dict,
+        combo=ifo)
+    bg_far_exc = significance.apply_far_limit(
+        bg_far_exc,
+        significance_dict,
+        combo=ifo)
     # Remove a small amount of time from the exclusive fore/background
     # time to account for this removal
     fg_time_exc -= n_removed * args.veto_window

--- a/bin/all_sky_search/pycbc_sngls_statmap
+++ b/bin/all_sky_search/pycbc_sngls_statmap
@@ -49,6 +49,11 @@ parser.add_argument('--veto-window', type=float, default=.1,
                     help='Time around each zerolag trigger to window out '
                          '[default=.1s]')
 significance.insert_significance_option_group(parser)
+parser.add_argument('--censor-ifar-threshold', type=float, default=0.5,
+                    help="Threshold to remove foreground triggers with "
+                         "IFAR (years) above this value from the exclusive "
+                         "background, and for hierarchical removal "
+                         "[default=0.5yr]")
 parser.add_argument('--hierarchical-removal-window', type=float, default=1.0,
                     help='Time around each trigger to window out for a very '
                          'louder trigger in the hierarchical removal '
@@ -151,9 +156,8 @@ f['background/ifar'] = conv.sec_to_year(bg_ifar)
 f.attrs['background_time'] = fg_time
 f.attrs['foreground_time'] = fg_time
 
-# Find foreground triggers with IFAR > 1 per livetime and remove from
-# the exclusive background (not equal, as that could give an infinite
-# loop if using count_n_louder)
+# Find foreground triggers with IFAR > the set limit and remove from
+# the exclusive background
 
 # Need to make copies for use as exclusive triggers as these will have
 # items removed from them, and don't want to overwrite the original
@@ -166,7 +170,7 @@ bkg_exc_dec_facs = copy.deepcopy(bkg_dec_facs)
 # Record indices into all_trigs for the exclusive background
 back_exc_locs = numpy.arange(len(all_trigs.stat))
 
-while any(bg_ifar_exc > fg_time):
+while any(conv.sec_to_year(bg_ifar_exc) > args.censor_ifar_threshold):
     # Find which fg events should be removed from exc background
     to_keep = bg_ifar_exc <= fg_time_exc
 
@@ -180,7 +184,7 @@ while any(bg_ifar_exc > fg_time):
 
     # Cumulative array of exclusive background triggers and the number
     # of exclusive background triggers louder than each foreground trigger
-    bg_far_exc, fg_far_exc = significance.get_far(
+    0bg_far_exc, fg_far_exc = significance.get_far(
         back_stat_exc,
         fore_stat,
         bkg_exc_dec_facs,
@@ -253,9 +257,9 @@ else :
 
 # Step 2 : Loop until we don't have to hierarchically remove anymore. This
 #          will happen when ifar_louder has no elements that are
-#          less than 1 per live time, or a set maximum.
+#          above the set threshold, or a set maximum.
 
-while numpy.any(ifar_louder >= fg_time):
+while numpy.any(conv.sec_to_year(ifar_louder) > args.censor_ifar_threshold):
     # If the user wants to stop doing hierarchical removals after a set
     # number of iterations then break when that happens.
     if (h_iterations == args.max_hierarchical_removal):

--- a/bin/all_sky_search/pycbc_sngls_statmap
+++ b/bin/all_sky_search/pycbc_sngls_statmap
@@ -246,23 +246,23 @@ orig_fore_stat = fore_stat
 if args.max_hierarchical_removal != 0:
     # If user wants to remove against inclusive background.
     if is_bkg_inc:
-        ifar_louder_yrs = conv.sec_to_year(fg_ifar)
+        ifar_louder_yr = conv.sec_to_year(fg_ifar)
     # Otherwise user wants to remove against exclusive background
     else :
-        ifar_louder_yrs = conv.sec_to_year(fg_ifar_exc)
+        ifar_louder_yr = conv.sec_to_year(fg_ifar_exc)
 else :
     # It doesn't matter if you choose inclusive or exclusive,
     # the while loop below will break if none are louder than
-    # ifar_louder_yrs, or at the comparison
+    # ifar_louder_yr, or at the comparison
     # h_iterations == args.max_hierarchical_removal. But this avoids
     # a NameError
-    ifar_louder_yrs = conv.sec_to_year(fg_ifar)
+    ifar_louder_yr = conv.sec_to_year(fg_ifar)
 
 # Step 2 : Loop until we don't have to hierarchically remove anymore. This
-#          will happen when ifar_louder_yrs has no elements that are
+#          will happen when ifar_louder_yr has no elements that are
 #          above the set threshold, or a set maximum.
 
-while numpy.any(ifar_louder_yrs > args.hierarchical_removal_ifar_threshold):
+while numpy.any(ifar_louder_yr > args.hierarchical_removal_ifar_threshold):
     # If the user wants to stop doing hierarchical removals after a set
     # number of iterations then break when that happens.
     if (h_iterations == args.max_hierarchical_removal):
@@ -286,7 +286,7 @@ while numpy.any(ifar_louder_yrs > args.hierarchical_removal_ifar_threshold):
 
     # Among foreground triggers, find the one with the largest ifar
     # and mark it for removal.
-    max_stat_idx = ifar_louder_yrs.argmax()
+    max_stat_idx = ifar_louder_yr.argmax()
 
     # Step 3: Remove that trigger from the list of zerolag triggers
 
@@ -341,10 +341,10 @@ while numpy.any(ifar_louder_yrs > args.hierarchical_removal_ifar_threshold):
     bg_ifar = 1. / bg_far
     fg_ifar = 1. / fg_far
 
-    # Update the ifar_louder_yrs criteria depending on whether foreground
+    # Update the ifar_louder_yr criteria depending on whether foreground
     # triggers are being removed via inclusive or exclusive background.
     if is_bkg_inc:
-        ifar_louder_yrs = conv.sec_to_year(fg_ifar)
+        ifar_louder_yr = conv.sec_to_year(fg_ifar)
 
     # Exclusive background doesn't change when removing foreground triggers.
     # So we don't have to take bg_far_exc, just repopulate fg_ifar_exc
@@ -358,7 +358,7 @@ while numpy.any(ifar_louder_yrs > args.hierarchical_removal_ifar_threshold):
 
         fg_ifar_exc = 1. / fg_far_exc
 
-        ifar_louder_yrs = conv.sec_to_year(fg_ifar_exc)
+        ifar_louder_yr = conv.sec_to_year(fg_ifar_exc)
 
     # louder_foreground has been updated and the code can continue.
 

--- a/bin/all_sky_search/pycbc_sngls_statmap
+++ b/bin/all_sky_search/pycbc_sngls_statmap
@@ -171,7 +171,7 @@ bkg_exc_dec_facs = copy.deepcopy(bkg_dec_facs)
 # Record indices into all_trigs for the exclusive background
 back_exc_locs = numpy.arange(len(all_trigs.stat))
 
-# Find which fg events should be removed from exc background
+# Remove trigs from 'exclusive' background if their IFAR is > livetime
 to_keep = bg_ifar_exc <= fg_time_exc
 
 n_removed = bg_ifar_exc.size - sum(to_keep)

--- a/bin/all_sky_search/pycbc_sngls_statmap
+++ b/bin/all_sky_search/pycbc_sngls_statmap
@@ -6,7 +6,7 @@ with producing the combined foreground and background triggers.
 """
 
 import argparse, h5py, itertools
-import lal, logging, numpy
+import lal, logging, numpy, copy
 from pycbc.events import veto, coinc
 from pycbc.events import triggers, trigger_fits as trstats
 from pycbc.events import significance
@@ -72,7 +72,6 @@ parser.add_argument('--hierarchical-removal-against', type=str,
 parser.add_argument('--output-file')
 args = parser.parse_args()
 
-
 significance.check_significance_options(args, parser)
 
 # Check that the user chose inclusive or exclusive background to perform
@@ -105,13 +104,8 @@ logging.info("We have %s triggers" % len(all_trigs.stat))
 logging.info("Clustering triggers")
 all_trigs = all_trigs.cluster(args.cluster_window)
 
-# For now, all triggers are both in the foreground and background
-fore_locs = numpy.flatnonzero(all_trigs.timeslide_id == 0)
-back_locs = numpy.flatnonzero(all_trigs.timeslide_id == 0)
-
 fg_time = float(all_trigs.attrs['foreground_time'])
-exc_veto_time = (len(back_locs) - len(back_locs)) * args.veto_window
-fg_time_exc = fg_time - exc_veto_time
+fg_time_exc = copy.deepcopy(fg_time)
 
 logging.info("Dumping foreground triggers")
 f = fw(args.output_file)
@@ -128,19 +122,18 @@ for key in all_trigs.seg.keys():
 f['segments/foreground_veto/start'] = numpy.array([0])
 f['segments/foreground_veto/end'] = numpy.array([0])
 for k in all_trigs.data:
-    f['foreground/' + k] = all_trigs.data[k][fore_locs]
-    f['background/' + k] = all_trigs.data[k][back_locs]
-    f['background_exc/' + k] = all_trigs.data[k][back_locs]
-
+    f['foreground/' + k] = all_trigs.data[k]
+    f['background/' + k] = all_trigs.data[k]
 
 logging.info("Estimating FAN from background statistic values")
 # Ranking statistic of foreground and background
-fore_stat = all_trigs.stat[fore_locs]
-back_stat = all_trigs.stat[back_locs]
-back_stat_exc = all_trigs.stat[back_locs]
+fore_stat = back_stat = all_trigs.stat
+# Need to make a copy as this will have items removed from it, and dont want
+# to overwrite the original
+back_stat_exc = copy.deepcopy(back_stat)
 
-bkg_dec_facs = all_trigs.decimation_factor[back_locs]
-bkg_exc_dec_facs = all_trigs.decimation_factor[back_locs]
+bkg_dec_facs = all_trigs.decimation_factor
+bkg_exc_dec_facs = all_trigs.decimation_factor
 
 significance_dict = significance.digest_significance_options([ifo], args)
 
@@ -153,29 +146,56 @@ bg_far, fg_far = significance.get_far(
     fg_time,
     **significance_dict[ifo])
 
-# Cumulative array of exclusive background triggers and the number
-# of exclusive background triggers louder than each foreground trigger
-bg_far_exc, fg_far_exc = significance.get_far(
-    back_stat_exc,
-    fore_stat,
-    bkg_exc_dec_facs,
-    fg_time_exc,
-    **significance_dict[ifo])
-
 fg_far = significance.apply_far_limit(fg_far, significance_dict, combo=ifo)
 bg_far = significance.apply_far_limit(bg_far, significance_dict, combo=ifo)
-fg_far_exc = significance.apply_far_limit(fg_far_exc, significance_dict, combo=ifo)
-bg_far_exc = significance.apply_far_limit(bg_far_exc, significance_dict, combo=ifo)
 
 bg_ifar = 1. / bg_far
 fg_ifar = 1. / fg_far
-bg_ifar_exc = 1. / bg_far_exc
-fg_ifar_exc = 1. / fg_far_exc
 
-f['background/ifar'] = conv.sec_to_year(bg_ifar)
-f['background_exc/ifar'] = conv.sec_to_year(bg_ifar_exc)
 f.attrs['background_time'] = fg_time
 f.attrs['foreground_time'] = fg_time
+
+# Find foreground triggers with IFAR > 1 per livetime and remove from
+# the exclusive background (not equal, as that could give an infinite
+# loop if using count_n_louder)
+fg_ifar_exc = copy.deepcopy(fg_ifar)
+bg_ifar_exc = copy.deepcopy(bg_ifar)
+
+# Variable to tell us which events to select from all_trigs for the
+# exclusive background
+back_exc_locs = numpy.arange(len(all_trigs.stat))
+
+while any(bg_ifar_exc > fg_time):
+    # Find which fg events should be removed from exc background
+    to_keep = bg_ifar_exc <= fg_time_exc
+
+    n_removed = bg_ifar_exc.size - sum(to_keep)
+    logging.info("Removing %s event(s) from exclusive background",
+                 n_removed)
+
+    back_stat_exc = back_stat_exc[to_keep]
+    bkg_exc_dec_facs = bkg_exc_dec_facs[to_keep]
+    back_exc_locs = back_exc_locs[to_keep]
+
+    # Cumulative array of exclusive background triggers and the number
+    # of exclusive background triggers louder than each foreground trigger
+    bg_far_exc, fg_far_exc = significance.get_far(
+        back_stat_exc,
+        fore_stat,
+        bkg_exc_dec_facs,
+        fg_time_exc,
+        **significance_dict[ifo])
+
+    bg_ifar_exc = 1. / bg_far_exc
+    fg_ifar_exc = 1. / fg_far_exc
+    # Remove a small amount of time from the exclusive fore/background
+    # time to account for this removal
+    fg_time_exc -= n_removed * args.veto_window
+
+for k in all_trigs.data:
+    f['background_exc/' + k] = all_trigs.data[k][back_exc_locs]
+
+f['background_exc/ifar'] = conv.sec_to_year(bg_ifar_exc)
 f.attrs['background_time_exc'] = fg_time_exc
 f.attrs['foreground_time_exc'] = fg_time_exc
 
@@ -237,16 +257,14 @@ while numpy.any(ifar_louder >= fg_time):
     if h_iterations == 0:
         f['background_h%s/stat' % h_iterations] = back_stat
         f['background_h%s/ifar' % h_iterations] = conv.sec_to_year(bg_ifar)
-        f['background_h%s/timeslide_id' % h_iterations] = all_trigs.data['timeslide_id'][back_locs]
+        for k in all_trigs.data:
+            f['background_h%s/' % h_iterations + k] = all_trigs.data[k]
         f['foreground_h%s/stat' % h_iterations] = fore_stat
         f['foreground_h%s/ifar' % h_iterations] = conv.sec_to_year(fg_ifar)
         f['foreground_h%s/ifar_exc' % h_iterations] = conv.sec_to_year(fg_ifar_exc)
         f['foreground_h%s/fap' % h_iterations] = fap
-        f['foreground_h%s/template_id' % h_iterations] = all_trigs.data['template_id'][fore_locs]
-        trig_id = all_trigs.data['%s/trigger_id' % ifo][fore_locs]
-        trig_time = all_trigs.data['%s/time' % ifo][fore_locs]
-        f['foreground_h%s/%s/time' % (h_iterations,ifo)] = trig_time
-        f['foreground_h%s/%s/trigger_id' % (h_iterations,ifo)] = trig_id
+        for k in all_trigs.data:
+            f['foreground_h%s/' % h_iterations + k] = all_trigs.data[k]
     # Add the iteration number of hierarchical removals done.
     h_iterations += 1
 
@@ -285,22 +303,17 @@ while numpy.any(ifar_louder >= fg_time):
     # Step 4: Re-cluster the triggers and calculate the inclusive ifar/fap
     logging.info("Clustering coinc triggers (inclusive of zerolag)")
     all_trigs = all_trigs.cluster(args.cluster_window)
-    fore_locs = all_trigs.timeslide_id == 0
 
-    logging.info("%s clustered foreground triggers" % fore_locs.sum())
+    logging.info("%s clustered foreground triggers" % len(all_trigs))
     logging.info("%s hierarchically removed foreground trigger(s)" % h_iterations)
-
-    back_locs = all_trigs.timeslide_id == 0
-    fore_locs = all_trigs.timeslide_id == 0
 
     logging.info("Dumping foreground triggers")
     logging.info("Dumping background triggers (inclusive of zerolag)")
     for k in all_trigs.data:
-         f['background_h%s/' % h_iterations + k] = all_trigs.data[k][back_locs]
+        f['background_h%s/' % h_iterations + k] = all_trigs.data[k]
 
     logging.info("Calculating FAN from background statistic values")
-    back_stat = all_trigs.stat[back_locs]
-    fore_stat = all_trigs.stat[fore_locs]
+    back_stat = fore_stat = all_trigs.stat
 
     bg_far, fg_far = significance.get_far(
         back_stat,
@@ -338,7 +351,7 @@ while numpy.any(ifar_louder >= fg_time):
     f.attrs['background_time_h%s' % h_iterations] = fg_time
     f.attrs['foreground_time_h%s' % h_iterations] = fg_time
 
-    if fore_locs.sum() > 0:
+    if len(all_trigs) > 0:
         # Write ranking statistic to file just for downstream plotting code
         f['foreground_h%s/stat' % h_iterations] = fore_stat
 
@@ -360,9 +373,9 @@ while numpy.any(ifar_louder >= fg_time):
         # These don't change with the iterations but should be written at every
         # level.
 
-        f['foreground_h%s/template_id' % h_iterations] = all_trigs.data['template_id'][fore_locs]
-        trig_id = all_trigs.data['%s/trigger_id' % ifo][fore_locs]
-        trig_time = all_trigs.data['%s/time' % ifo][fore_locs]
+        f['foreground_h%s/template_id' % h_iterations] = all_trigs.data['template_id']
+        trig_id = all_trigs.data['%s/trigger_id' % ifo]
+        trig_time = all_trigs.data['%s/time' % ifo]
         f['foreground_h%s/%s/time' % (h_iterations,ifo)] = trig_time
         f['foreground_h%s/%s/trigger_id' % (h_iterations,ifo)] = trig_id
     else :

--- a/bin/all_sky_search/pycbc_sngls_statmap
+++ b/bin/all_sky_search/pycbc_sngls_statmap
@@ -49,7 +49,8 @@ parser.add_argument('--veto-window', type=float, default=.1,
                     help='Time around each zerolag trigger to window out '
                          '[default=.1s]')
 significance.insert_significance_option_group(parser)
--parser.add_argument('--censor-ifar-threshold', type=float, default=0.5,
+parser.add_argument('--hierarchical-removal-ifar-threshold',
+                    type=float, default=0.5,
                     help="Threshold to remove foreground triggers with "
                          "IFAR (years) above this value from the exclusive "
                          "background, and for hierarchical removal "
@@ -245,23 +246,23 @@ orig_fore_stat = fore_stat
 if args.max_hierarchical_removal != 0:
     # If user wants to remove against inclusive background.
     if is_bkg_inc:
-        ifar_louder = fg_ifar
+        ifar_louder_yrs = conv.sec_to_year(fg_ifar)
     # Otherwise user wants to remove against exclusive background
     else :
-        ifar_louder = fg_ifar_exc
+        ifar_louder_yrs = conv.sec_to_year(fg_ifar_exc)
 else :
     # It doesn't matter if you choose inclusive or exclusive,
-    # the while loop below will break if none are louder than ifar_louder,
-    # or at the comparison
+    # the while loop below will break if none are louder than
+    # ifar_louder_yrs, or at the comparison
     # h_iterations == args.max_hierarchical_removal. But this avoids
     # a NameError
-    ifar_louder = fg_ifar
+    ifar_louder_yrs = conv.sec_to_year(fg_ifar)
 
 # Step 2 : Loop until we don't have to hierarchically remove anymore. This
-#          will happen when ifar_louder has no elements that are
+#          will happen when ifar_louder_yrs has no elements that are
 #          above the set threshold, or a set maximum.
 
-while numpy.any(conv.sec_to_year(ifar_louder) > args.censor_ifar_threshold):
+while numpy.any(ifar_louder_yrs > args.hierarchical_removal_ifar_threshold):
     # If the user wants to stop doing hierarchical removals after a set
     # number of iterations then break when that happens.
     if (h_iterations == args.max_hierarchical_removal):
@@ -285,7 +286,7 @@ while numpy.any(conv.sec_to_year(ifar_louder) > args.censor_ifar_threshold):
 
     # Among foreground triggers, find the one with the largest ifar
     # and mark it for removal.
-    max_stat_idx = ifar_louder.argmax()
+    max_stat_idx = ifar_louder_yrs.argmax()
 
     # Step 3: Remove that trigger from the list of zerolag triggers
 
@@ -340,10 +341,10 @@ while numpy.any(conv.sec_to_year(ifar_louder) > args.censor_ifar_threshold):
     bg_ifar = 1. / bg_far
     fg_ifar = 1. / fg_far
 
-    # Update the ifar_louder criteria depending on whether foreground
+    # Update the ifar_louder_yrs criteria depending on whether foreground
     # triggers are being removed via inclusive or exclusive background.
     if is_bkg_inc:
-        ifar_louder = fg_ifar
+        ifar_louder_yrs = conv.sec_to_year(fg_ifar)
 
     # Exclusive background doesn't change when removing foreground triggers.
     # So we don't have to take bg_far_exc, just repopulate fg_ifar_exc
@@ -357,7 +358,7 @@ while numpy.any(conv.sec_to_year(ifar_louder) > args.censor_ifar_threshold):
 
         fg_ifar_exc = 1. / fg_far_exc
 
-        ifar_louder = fg_ifar_exc
+        ifar_louder_yrs = conv.sec_to_year(fg_ifar_exc)
 
     # louder_foreground has been updated and the code can continue.
 

--- a/bin/all_sky_search/pycbc_sngls_statmap
+++ b/bin/all_sky_search/pycbc_sngls_statmap
@@ -49,7 +49,7 @@ parser.add_argument('--veto-window', type=float, default=.1,
                     help='Time around each zerolag trigger to window out '
                          '[default=.1s]')
 significance.insert_significance_option_group(parser)
-parser.add_argument('--censor-ifar-threshold', type=float, default=0.5,
+-parser.add_argument('--censor-ifar-threshold', type=float, default=0.5,
                     help="Threshold to remove foreground triggers with "
                          "IFAR (years) above this value from the exclusive "
                          "background, and for hierarchical removal "
@@ -170,40 +170,42 @@ bkg_exc_dec_facs = copy.deepcopy(bkg_dec_facs)
 # Record indices into all_trigs for the exclusive background
 back_exc_locs = numpy.arange(len(all_trigs.stat))
 
-while any(conv.sec_to_year(bg_ifar_exc) > args.censor_ifar_threshold):
-    # Find which fg events should be removed from exc background
-    to_keep = bg_ifar_exc <= fg_time_exc
+# Find which fg events should be removed from exc background
+to_keep = bg_ifar_exc <= fg_time_exc
 
-    n_removed = bg_ifar_exc.size - sum(to_keep)
-    logging.info("Removing %s event(s) from exclusive background",
-                 n_removed)
+n_removed = bg_ifar_exc.size - sum(to_keep)
+logging.info("Removing %s event(s) from exclusive background",
+             n_removed)
 
-    back_stat_exc = back_stat_exc[to_keep]
-    bkg_exc_dec_facs = bkg_exc_dec_facs[to_keep]
-    back_exc_locs = back_exc_locs[to_keep]
+back_stat_exc = back_stat_exc[to_keep]
+bkg_exc_dec_facs = bkg_exc_dec_facs[to_keep]
+back_exc_locs = back_exc_locs[to_keep]
 
-    # Cumulative array of exclusive background triggers and the number
-    # of exclusive background triggers louder than each foreground trigger
-    0bg_far_exc, fg_far_exc = significance.get_far(
-        back_stat_exc,
-        fore_stat,
-        bkg_exc_dec_facs,
-        fg_time_exc,
-        **significance_dict[ifo])
+# Cumulative array of exclusive background triggers and the number
+# of exclusive background triggers louder than each foreground trigger
+bg_far_exc, fg_far_exc = significance.get_far(
+    back_stat_exc,
+    fore_stat,
+    bkg_exc_dec_facs,
+    fg_time_exc,
+    **significance_dict[ifo])
 
-    bg_ifar_exc = 1. / bg_far_exc
-    fg_ifar_exc = 1. / fg_far_exc
-    fg_far_exc = significance.apply_far_limit(
-        fg_far_exc,
-        significance_dict,
-        combo=ifo)
-    bg_far_exc = significance.apply_far_limit(
-        bg_far_exc,
-        significance_dict,
-        combo=ifo)
-    # Remove a small amount of time from the exclusive fore/background
-    # time to account for this removal
-    fg_time_exc -= n_removed * args.veto_window
+fg_far_exc = significance.apply_far_limit(
+    fg_far_exc,
+    significance_dict,
+    combo=ifo)
+
+bg_far_exc = significance.apply_far_limit(
+    bg_far_exc,
+    significance_dict,
+    combo=ifo)
+
+bg_ifar_exc = 1. / bg_far_exc
+fg_ifar_exc = 1. / fg_far_exc
+
+# Remove a small amount of time from the exclusive fore/background
+# time to account for this removal
+fg_time_exc -= n_removed * args.veto_window
 
 for k in all_trigs.data:
     f['background_exc/' + k] = all_trigs.data[k][back_exc_locs]

--- a/bin/all_sky_search/pycbc_sngls_statmap
+++ b/bin/all_sky_search/pycbc_sngls_statmap
@@ -163,8 +163,7 @@ f.attrs['foreground_time'] = fg_time
 fg_ifar_exc = copy.deepcopy(fg_ifar)
 bg_ifar_exc = copy.deepcopy(bg_ifar)
 
-# Variable to tell us which events to select from all_trigs for the
-# exclusive background
+# Record indices into all_trigs for the exclusive background
 back_exc_locs = numpy.arange(len(all_trigs.stat))
 
 while any(bg_ifar_exc > fg_time):

--- a/bin/all_sky_search/pycbc_sngls_statmap
+++ b/bin/all_sky_search/pycbc_sngls_statmap
@@ -105,7 +105,6 @@ logging.info("Clustering triggers")
 all_trigs = all_trigs.cluster(args.cluster_window)
 
 fg_time = float(all_trigs.attrs['foreground_time'])
-fg_time_exc = copy.deepcopy(fg_time)
 
 logging.info("Dumping foreground triggers")
 f = fw(args.output_file)
@@ -128,12 +127,7 @@ for k in all_trigs.data:
 logging.info("Estimating FAN from background statistic values")
 # Ranking statistic of foreground and background
 fore_stat = back_stat = all_trigs.stat
-# Need to make a copy as this will have items removed from it, and dont want
-# to overwrite the original
-back_stat_exc = copy.deepcopy(back_stat)
-
 bkg_dec_facs = all_trigs.decimation_factor
-bkg_exc_dec_facs = all_trigs.decimation_factor
 
 significance_dict = significance.digest_significance_options([ifo], args)
 
@@ -160,8 +154,14 @@ f.attrs['foreground_time'] = fg_time
 # Find foreground triggers with IFAR > 1 per livetime and remove from
 # the exclusive background (not equal, as that could give an infinite
 # loop if using count_n_louder)
+
+# Need to make copies for use as exclusive triggers as these will have
+# items removed from them, and don't want to overwrite the original
+fg_time_exc = copy.deepcopy(fg_time)
 fg_ifar_exc = copy.deepcopy(fg_ifar)
 bg_ifar_exc = copy.deepcopy(bg_ifar)
+back_stat_exc = copy.deepcopy(back_stat)
+bkg_exc_dec_facs = copy.deepcopy(bkg_dec_facs)
 
 # Record indices into all_trigs for the exclusive background
 back_exc_locs = numpy.arange(len(all_trigs.stat))

--- a/bin/all_sky_search/pycbc_sngls_statmap
+++ b/bin/all_sky_search/pycbc_sngls_statmap
@@ -162,7 +162,7 @@ f.attrs['foreground_time'] = fg_time
 
 # Need to make copies for use as exclusive triggers as these will have
 # items removed from them, and don't want to overwrite the original
-fg_time_exc = copy.deepcopy(fg_time)
+fg_time_exc = fg_time
 fg_ifar_exc = copy.deepcopy(fg_ifar)
 bg_ifar_exc = copy.deepcopy(bg_ifar)
 back_stat_exc = copy.deepcopy(back_stat)

--- a/bin/all_sky_search/pycbc_sngls_statmap
+++ b/bin/all_sky_search/pycbc_sngls_statmap
@@ -152,6 +152,8 @@ bg_far = significance.apply_far_limit(bg_far, significance_dict, combo=ifo)
 bg_ifar = 1. / bg_far
 fg_ifar = 1. / fg_far
 
+f['background/ifar'] = conv.sec_to_year(bg_ifar)
+
 f.attrs['background_time'] = fg_time
 f.attrs['foreground_time'] = fg_time
 

--- a/bin/all_sky_search/pycbc_sngls_statmap_inj
+++ b/bin/all_sky_search/pycbc_sngls_statmap_inj
@@ -110,14 +110,18 @@ significance_dict = significance.digest_significance_options([ifo], args)
 
 # Cumulative array of exclusive background triggers and the number
 # of exclusive background triggers louder than each foreground trigger
-back_cnum_exc, fnlouder_exc = significance.get_n_louder(
+bg_far_exc, fg_far_exc = significance.get_far(
     back_stat_exc,
     fore_stat,
     bkg_exc_dec_facs,
+    fg_time_exc,
     **significance_dict[ifo])
 
-fg_ifar_exc = fg_time_exc / (fnlouder_exc + 1)
-bg_ifar_exc = fg_time_exc / (back_cnum_exc + 1)
+fg_far_exc = significance.apply_far_limit(fg_far_exc, significance_dict, combo=ifo)
+bg_far_exc = significance.apply_far_limit(bg_far_exc, significance_dict, combo=ifo)
+
+fg_ifar_exc = 1. / fg_far_exc
+bg_ifar_exc = 1. / bg_far_exc
 
 f['background_exc/ifar'] = conv.sec_to_year(bg_ifar_exc)
 f.attrs['background_time_exc'] = fg_time_exc

--- a/bin/minifollowups/pycbc_plot_trigger_timeseries
+++ b/bin/minifollowups/pycbc_plot_trigger_timeseries
@@ -19,6 +19,7 @@ import argparse, logging, pycbc.version, pycbc.results, sys
 from pycbc.types import MultiDetOptionAction
 from pycbc.events import ranking
 from pycbc.io import HFile
+import h5py
 import matplotlib; matplotlib.use('Agg'); import pylab
 import numpy
 
@@ -39,8 +40,9 @@ parser.add_argument('--times', nargs='+', type=float,
 parser.add_argument('--special-trigger-ids', nargs='+', type=int,
     action=MultiDetOptionAction, metavar="IFO:GPS_TIME",
     help="The set of special trigger ids to plot a star at")
-parser.add_argument('--plot-type', choices=['snr', 'newsnr'], default='snr',
-    help="Which plot to make; an 'snr' or a newsnr' plot.")
+parser.add_argument('--plot-type',
+    choices=ranking.sngls_ranking_function_dict, default='snr',
+    help="Which single-detector ranking statistic to plot.")
 parser.add_argument('--output-file')
 parser.add_argument('--log-y-axis', action='store_true')
 
@@ -49,73 +51,80 @@ pycbc.init_logging(args.verbose)
 
 any_data = False
 
-# organize the single detector triggers files by ifo in a dict
 fig = pylab.figure()
-for ifo in args.single_trigger_files.keys():
-    t = args.times[ifo]
 
-    if args.special_trigger_ids:
-        id_loud = args.special_trigger_ids[ifo]
+min_rank = numpy.inf
+for ifo in args.single_trigger_files.keys():
+    logging.info("Getting %s triggers", ifo)
+    t = args.times[ifo]
 
     data = HFile(args.single_trigger_files[ifo], 'r')
 
     # Identify trigger indices within window
-    select_func = lambda *inputs: ((inputs[0] < (t + args.window)) & 
-                                   (inputs[0] > (t - args.window)))
-    times, snr, chisq, chisq_dof = data.select(select_func, ifo + '/end_time',
-                                               ifo + '/snr', ifo + '/chisq',
-                                               ifo + '/chisq_dof')
-                                 
-    # center times on the trigger/chosen time
-    times = times - t
+    keep = abs(data[ifo + '/end_time'][:] - t) < args.window
+    if not any(keep):
+        # No triggers in this window, add to the legend and continue
+        # Make sure it isnt on the plot
+        pylab.scatter(-2 * args.window, 0,
+                      color=pycbc.results.ifo_color(ifo),
+                      marker='x',
+                      label=ifo)
+        continue
 
-    if args.plot_type == 'snr':
-        val = snr
+    any_data = True
+    logging.info("Keeping %d triggers in the window", sum(keep))
 
-        if args.special_trigger_ids:
-            top = data[ifo]['snr'][id_loud]
 
-    if args.plot_type == 'newsnr':
-        rchisq = chisq / (2 * chisq_dof - 2)
-        if len(rchisq) > 0:
-            val = ranking.newsnr(snr, rchisq)
-        else:
-            val = numpy.array([])
+    data_dict = {k: data[ifo][k][keep] for k in data[ifo]
+                 if isinstance(data[ifo][k], h5py.Dataset)
+                 and data[ifo][k].size == keep.size}
 
-        # Get the newnsr of the loudest trigger so we can plot a star there
-        if args.special_trigger_ids:
-            rchisq = data[ifo]['chisq'][id_loud] / \
-                (data[ifo]['chisq_dof'][id_loud] * 2 - 2)
-            top = ranking.newsnr(data[ifo]['snr'][id_loud], rchisq)
+    logging.info("Getting %s", args.plot_type)
+    rank = ranking.get_sngls_ranking_from_trigs(data_dict, args.plot_type)
 
-    if type(val) in [numpy.float32, numpy.float64] or len(val) > 0:
-        any_data = True
+    if all(rank == 1):
+        # This is the default value to say "downranked beyond consideration"
+        # so skip these events
+        pylab.scatter(-2 * args.window, 0,
+                      color=pycbc.results.ifo_color(ifo),
+                      marker='x',
+                      label=ifo)
+        continue
 
-    pylab.scatter(times, val, color=pycbc.results.ifo_color(ifo), marker='x',
+    pylab.scatter(data_dict['end_time'] - t, rank,
+                  color=pycbc.results.ifo_color(ifo), marker='x',
                   label=ifo)
 
+    # Minimum rank which hasn't been set to the default of 1
+    min_rank = min(min_rank, rank[rank > 1].min())
+
     if args.special_trigger_ids:
-        any_data = True
-        pylab.scatter([0], [top], marker='*', s=50, color='yellow')
+        special_idx = numpy.flatnonzero(keep) == args.special_trigger_ids[ifo]
+        if not any(special_idx):
+            logging.info("IDX %d not in kept list", args.special_trigger_ids[ifo])
+            continue
+
+        pylab.scatter((data_dict['end_time'] - t)[special_idx],
+                      rank[special_idx], marker='*', s=50, color='yellow')
 
 if args.log_y_axis and any_data:
     pylab.yscale('log')
 
+if not numpy.isinf(min_rank):
+    pylab.ylim(ymin=min_rank)
+
 pylab.xlabel('time (s)')
 pylab.ylabel(args.plot_type)
-
-try:
-    if len(val) > 0:
-        pylab.ylim(ymin=val.min())
-except TypeError:
-    pylab.ylim(ymin=val)
 
 pylab.xlim(xmin=-args.window, xmax=args.window)
 pylab.legend()
 pylab.grid()
+
+logging.info("Saving figure")
 pycbc.results.save_fig_with_metadata(fig, args.output_file,
             cmd = ' '.join(sys.argv),
             title = 'Single Detector Trigger Timeseries (%s)' % args.plot_type,
             caption = 'Time series showing the single detector triggers'
                       ' centered around the time of the trigger of interest.',
          )
+logging.info("Done!")

--- a/bin/plotting/pycbc_page_foundmissed
+++ b/bin/plotting/pycbc_page_foundmissed
@@ -47,8 +47,9 @@ parser.add_argument('--dynamic', action='store_true', default=False)
 parser.add_argument('--gradient-far', action='store_true',
                     help="Show far of found injections as a gradient")
 parser.add_argument('--output-file', required=True)
-parser.add_argument('--limit-ifar', type=float,
-                    help="Supply a limit for IFAR colors")
+parser.add_argument('--ifar-limits', nargs=2, type=float,
+                    help="Supply upper and lower limits for IFAR colors. "
+                         "0 indicates no limit.")
 parser.add_argument('--far-type', choices=('inclusive', 'exclusive'),
                     default='inclusive',
                     help="Type of far to plot for the color. Choices are "
@@ -75,8 +76,19 @@ elif args.far_type == 'exclusive':
     ifar_found = f['found_after_vetoes/ifar_exc'][:]
     far_title = 'Exclusive'
 
-if args.limit_ifar:
-    ifar_found = numpy.minimum(ifar_found, args.limit_ifar)
+upper_lim = False
+lower_lim = False
+if args.ifar_limits:
+    if args.ifar_limits[0] < 0 or args.ifar_limits[1] < 0:
+        parser.error("IFAR limits must be zero (no limit) or positive")
+    if args.ifar_limits[0] > 0:
+        # Lower limit on IFAR
+        lower_lim = True
+        ifar_found = numpy.maximum(ifar_found, args.ifar_limits[0])
+    if args.ifar_limits[1] > 0:
+        # Upper limit on IFAR
+        upper_lim = True
+        ifar_found = numpy.minimum(ifar_found, args.ifar_limits[1])
 
 s1z = f['injections/spin1z'][:]
 s2z = f['injections/spin2z'][:]
@@ -202,7 +214,15 @@ points = plot.scatter(fvals, fdval, c=color, linewidth=0, s=16, norm=norm,
                       cmap=args.colormap)
 if args.gradient_far:
     try:
-        c = plot.colorbar()
+        if upper_lim and lower_lim:
+            ext = 'both'
+        elif lower_lim and not upper_lim:
+            ext = 'max'
+        elif upper_lim and not lower_lim:
+            ext = 'min'
+        else:
+            ext = 'neither'
+        c = plot.colorbar(extend=ext)
         c.set_label('False Alarm Rate $(yr^{-1})$, %s' % far_title)
 
         # Set up tick labels - there will be 5 if possible

--- a/bin/plotting/pycbc_page_sensitivity
+++ b/bin/plotting/pycbc_page_sensitivity
@@ -210,14 +210,14 @@ elif args.sig_type == 'ifar':
     xlabel = 'Inverse False Alarm Rate (years)'
     if args.sig_bins:
         x_values = [float(v) for v in args.sig_bins]
-    else:
-        x_values = 10. ** (numpy.arange(0, 4, .05))
+    else:  # From approx 2 per day to 1 per 10,000yr
+        x_values = 10. ** (numpy.arange(-3, 4, .1))
 elif args.sig_type == 'fap':
     xlabel = 'False Alarm Probability'
     if args.sig_bins:
         x_values = [float(v) for v in args.sig_bins]
-    else:
-        x_values = 10. ** -numpy.arange(1, 7)
+    else:  # From ~0.3 down to 1e-6
+        x_values = 10. ** numpy.arange(-0.5, -6, -0.5)
 
 if args.hdf_out:
     plotdict = {}

--- a/pycbc/events/significance.py
+++ b/pycbc/events/significance.py
@@ -28,11 +28,12 @@ read in the associated options to do so.
 """
 import logging
 import copy
+import lal
 import numpy as np
 from pycbc.events import trigger_fits as trstats
 
 
-def count_n_louder(bstat, fstat, dec, skip_background=False,
+def count_n_louder(bstat, fstat, dec,
                    **kwargs):  # pylint:disable=unused-argument
     """ Calculate for each foreground event the number of background events
     that are louder than it.
@@ -45,14 +46,11 @@ def count_n_louder(bstat, fstat, dec, skip_background=False,
         Array of the foreground statistic values or single value
     dec: numpy.ndarray
         Array of the decimation factors for the background statistics
-    skip_background: optional, {boolean, False}
-        Skip calculating cumulative numbers for background triggers
 
     Returns
     -------
     cum_back_num: numpy.ndarray
-        The cumulative array of background triggers. Does not return this
-        argument if skip_background == True
+        The cumulative array of background triggers.
     fore_n_louder: numpy.ndarray
         The number of background triggers above each foreground trigger
     """
@@ -82,16 +80,14 @@ def count_n_louder(bstat, fstat, dec, skip_background=False,
 
     fore_n_louder = n_louder[idx]
 
-    if not skip_background:
-        unsort = sort.argsort()
-        back_cum_num = n_louder[unsort]
-        return back_cum_num, fore_n_louder
-
-    return fore_n_louder
+    unsort = sort.argsort()
+    back_cum_num = n_louder[unsort]
+    return back_cum_num, fore_n_louder
 
 
 def n_louder_from_fit(back_stat, fore_stat, dec_facs,
-                      fit_function='exponential', fit_threshold=0):
+                      fit_function='exponential', fit_threshold=0,
+                      **kwargs):  # pylint:disable=unused-argument
     """
     Use a fit to events in back_stat in order to estimate the
     distribution for use in recovering the estimate count of louder
@@ -113,10 +109,10 @@ def n_louder_from_fit(back_stat, fore_stat, dec_facs,
 
     Returns
     -------
-    back_cnum: numpy.ndarray
+    bg_n_louder: numpy.ndarray
         The estimated number of background events louder than each
         background event
-    fn_louder: numpy.ndarray
+    fg_n_louder: numpy.ndarray
         The estimated number of background events louder than each
         foreground event
     """
@@ -134,18 +130,18 @@ def n_louder_from_fit(back_stat, fore_stat, dec_facs,
 
     # These will be overwritten, but just to silence a warning
     # in the case where trstats.cum_fit returns zero
-    back_cnum = np.zeros_like(back_stat)
-    fnlouder = np.zeros_like(fore_stat)
+    bg_n_louder = np.zeros_like(back_stat)
+    fg_n_louder = np.zeros_like(fore_stat)
 
     # Ue the fit above the threshold
-    back_cnum[bg_above] = n_above * trstats.cum_fit(fit_function,
-                                                    back_stat[bg_above],
-                                                    alpha,
-                                                    fit_threshold)
-    fnlouder[fg_above] = n_above * trstats.cum_fit(fit_function,
-                                                   fore_stat[fg_above],
-                                                   alpha,
-                                                   fit_threshold)
+    bg_n_louder[bg_above] = n_above * trstats.cum_fit(fit_function,
+                                                      back_stat[bg_above],
+                                                      alpha,
+                                                      fit_threshold)
+    fg_n_louder[fg_above] = n_above * trstats.cum_fit(fit_function,
+                                                      fore_stat[fg_above],
+                                                      alpha,
+                                                      fit_threshold)
 
     # Below the fit threshold, we expect there to be sufficient events
     # to use the count_n_louder method, and the distribution may deviate
@@ -155,16 +151,16 @@ def n_louder_from_fit(back_stat, fore_stat, dec_facs,
 
     # Count the number of below-threshold background events louder than the
     # bg and foreground
-    back_cnum[bg_below], fnlouder[fg_below] = \
+    bg_n_louder[bg_below], fg_n_louder[fg_below] = \
         count_n_louder(back_stat[bg_below], fore_stat[fg_below], dec_facs)
 
     # As we have only counted the louder below-threshold events, need to
     # add the above threshold events, which by definition are louder than
     # all the below-threshold events
-    back_cnum[bg_below] += n_above
-    fnlouder[fg_below] += n_above
+    bg_n_louder[bg_below] += n_above
+    fg_n_louder[fg_below] += n_above
 
-    return back_cnum, fnlouder
+    return bg_n_louder, fg_n_louder
 
 
 _significance_meth_dict = {
@@ -175,7 +171,8 @@ _significance_meth_dict = {
 _default_opt_dict = {
     'method': 'n_louder',
     'fit_threshold': None,
-    'fit_function': None}
+    'fit_function': None,
+    'far_limit': 0.}
 
 
 def get_n_louder(back_stat, fore_stat, dec_facs,
@@ -190,6 +187,54 @@ def get_n_louder(back_stat, fore_stat, dec_facs,
         fore_stat,
         dec_facs,
         **kwargs)
+
+
+def get_far(back_stat, fore_stat, dec_facs,
+            background_time,
+            method=_default_opt_dict['method'],
+            **kwargs):  # pylint:disable=unused-argument
+    """
+    Return the appropriate FAR given the significance calculation method
+
+    If the n_louder method is used, find the IFAR according to Eq.17-18
+    of Usman et al., arXiv:1508.02357. The p-value of a candidate in a
+    search of duration T, with n_bg louder time shifted events over a
+    total background time T_bg is
+    `p = 1 - exp(-T * (n_bg + 1) / T_bg)`
+    corresponding to an effective false alarm rate of (n_bg + 1) / T_bg.
+
+    If the trigger_fit method is used, we are extrapolating the background
+    for the specific aim of FAR not being limited to 1 / T_bg, and so we
+    do not add 1 to n_bg
+
+    Parameters
+    ----------
+    See description in get_n_louder for most parameters
+
+    background_time: float
+       The amount of time to convert the number of louder events into
+       a FAR
+
+    """
+    bg_n_louder, fg_n_louder = get_n_louder(
+        back_stat,
+        fore_stat,
+        dec_facs,
+        method=method,
+        **kwargs
+    )
+
+    # If we are counting the number of louder events in the background,
+    # we add one. This is part of the p-value calculation in Usman 2015.
+    # If we are doing trigger fit extrapolation, this is not needed
+    if method == 'n_louder':
+        bg_n_louder += 1
+        fg_n_louder += 1
+
+    bg_far = bg_n_louder / background_time
+    fg_far = fg_n_louder / background_time
+
+    return bg_far, fg_far
 
 
 def insert_significance_option_group(parser):
@@ -219,6 +264,26 @@ def insert_significance_option_group(parser):
                              "Options: ["
                              + ",".join(trstats.fitalpha_dict.keys()) + "]. "
                              "Default = exponential for all")
+    parser.add_argument('--limit-ifar', nargs='+', default=[],
+                        help="Impose upper limits on IFAR values (years)"
+                             ". Given as combination:value pairs, eg "
+                             "H1L1:10000 L1:1000. Used to avoid under/"
+                             "overflows for loud signals and injections "
+                             "using the fit extrapolation method. A value"
+                             " 0 or no value means unlimited IFAR")
+
+
+def positive_float(inp):
+    """
+    Wrapper around float conversion which ensures that the float must be
+    positive or zero
+    """
+    fl_in = float(inp)
+    if fl_in < 0:
+        logging.warning("Value provided to positive_float is less than zero, "
+                        "this is not allowed")
+        raise ValueError
+    return fl_in
 
 
 def check_significance_options(args, parser):
@@ -231,8 +296,8 @@ def check_significance_options(args, parser):
                        _significance_meth_dict.keys()),
                       (args.fit_function, str,
                        trstats.fitalpha_dict.keys()),
-                      (args.fit_threshold, float,
-                       None)]
+                      (args.fit_threshold, float, None),
+                      (args.limit_ifar, positive_float, None)]
 
     for list_to_check, type_to_convert, allowed_values in lists_to_check:
         combo_list = []
@@ -284,6 +349,24 @@ def check_significance_options(args, parser):
             parser.error("Threshold required for combo " + combo)
 
 
+def ifar_opt_to_far_limit(ifar_str):
+    """
+    Convert the string of an IFAR limit in years into a
+    float FAR limit in Hz.
+
+    Parameters
+    ----------
+    ifar_str: string
+        Upper limit on IFAR in years. Zero indicates no upper limit
+
+    """
+    ifar_float = positive_float(ifar_str)
+
+    far_hz = 0. if (ifar_float == 0.) else 1. / (lal.YRJUL_SI * ifar_float)
+
+    return far_hz
+
+
 def digest_significance_options(combo_keys, args):
     """
     Read in information from the significance option group and ensure
@@ -302,12 +385,13 @@ def digest_significance_options(combo_keys, args):
     -------
     significance_dict: dictionary
         Dictionary containing method, threshold and function for trigger fits
-        as appropriate
+        as appropriate, and any limit on FAR (Hz)
     """
 
     lists_to_unpack = [('method', args.far_calculation_method, str),
                        ('fit_function', args.fit_function, str),
-                       ('fit_threshold', args.fit_threshold, float)]
+                       ('fit_threshold', args.fit_threshold, float),
+                       ('far_limit', args.limit_ifar, ifar_opt_to_far_limit)]
 
     significance_dict = {}
     # Set everything as a default to start with:
@@ -328,3 +412,52 @@ def digest_significance_options(combo_keys, args):
             significance_dict[combo][argument_key] = conv_func(value)
 
     return significance_dict
+
+
+def apply_far_limit(far, significance_dict, combo=None):
+    """
+    Apply a FAR limit to events according to command line options.
+
+    If far_limit in significance_dict is zero, no limit is applied.
+
+    Parameters
+    ----------
+    far: numpy array
+    significance_dict: dictionary
+        Dictionary containing any limit on FAR (Hz), made by
+        digest_significance_options
+    active_combination: numpy.array or string
+        Array of IFO combinations given as utf-8 encoded strings, or a string
+        which defines the IFO combination for all events
+
+    Returns
+    -------
+    far_out: numpy array
+        FARs with far limit applied as appropriate
+
+    """
+    far_out = copy.deepcopy(far)
+    if isinstance(combo, str):
+        # Single IFO combo used
+        if significance_dict[combo]['far_limit'] == 0:
+            return far_out
+        far_limit_str = f"{significance_dict[combo]['far_limit']:.3e}"
+        logging.info("Applying FAR limit of %s to %s events",
+                     far_limit_str, combo)
+        far_out = np.maximum(far, significance_dict[combo]['far_limit'])
+    else:
+        # IFO combo supplied as an array, by e.g. pycbc_add_statmap
+        # Need to check which events are in which IFO combo in order to
+        # apply the right limit to each
+        for ifo_combo in significance_dict:
+            if significance_dict[ifo_combo]['far_limit'] == 0:
+                continue
+            far_limit_str = f"{significance_dict[ifo_combo]['far_limit']:.3e}"
+            logging.info("Applying FAR limit of %s to %s events",
+                         far_limit_str, ifo_combo)
+            this_combo_idx = combo == ifo_combo.encode('utf-8')
+            far_out[this_combo_idx] = np.maximum(
+                far[this_combo_idx],
+                significance_dict[ifo_combo]['far_limit']
+            )
+    return far_out

--- a/pycbc/pnutils.py
+++ b/pycbc/pnutils.py
@@ -31,7 +31,7 @@ import numpy
 from scipy.optimize import bisect, brentq, minimize
 from pycbc import conversions, libutils
 
-lalsimulation = libutils.import_optional('lalsimulation')
+lalsim = libutils.import_optional('lalsimulation')
 
 def nearest_larger_binary_number(input_len):
     """ Return the nearest binary number larger than input_len.
@@ -85,7 +85,7 @@ def eta_mass1_to_mass2(eta, mass1, return_mass_heavier=False, force_real=True):
     second component mass. Similar to mchirp_mass1_to_mass2 this requires
     finding the roots of a quadratic equation. Basically:
 
-    eta m2^2 + (2 eta - 1)m1 m2 + \eta m1^2 = 0
+    eta m2^2 + (2 eta - 1)m1 m2 + eta m1^2 = 0
 
     This has two solutions which correspond to mass1 being the heavier mass
     or it being the lighter mass. By default the value corresponding to
@@ -318,8 +318,7 @@ def f_LRD(m1, m2):
     return 1.2 * f_FRD(m1, m2)
 
 def _get_freq(freqfunc, m1, m2, s1z, s2z):
-    """
-    Wrapper of the LALSimulation function returning the frequency
+    """Wrapper of the LALSimulation function returning the frequency
     for a given frequency function and template parameters.
 
     Parameters
@@ -340,11 +339,17 @@ def _get_freq(freqfunc, m1, m2, s1z, s2z):
     f : float
         Frequency in Hz
     """
-    # Convert to SI units for lalsimulation
-    m1kg = float(m1) * lal.MSUN_SI
-    m2kg = float(m2) * lal.MSUN_SI
-    return lalsimulation.SimInspiralGetFrequency(
-        m1kg, m2kg, 0, 0, float(s1z), 0, 0, float(s2z), int(freqfunc))
+    return lalsim.SimInspiralGetFrequency(
+        solar_mass_to_kg(m1),
+        solar_mass_to_kg(m2),
+        0,
+        0,
+        float(s1z),
+        0,
+        0,
+        float(s2z),
+        int(freqfunc)
+    )
 
 # vectorize to enable calls with numpy arrays
 _vec_get_freq = numpy.vectorize(_get_freq)
@@ -372,12 +377,11 @@ def get_freq(freqfunc, m1, m2, s1z, s2z):
     f : float or numpy.array
         Frequency in Hz
     """
-    lalsim_ffunc = getattr(lalsimulation, freqfunc)
+    lalsim_ffunc = getattr(lalsim, freqfunc)
     return _vec_get_freq(lalsim_ffunc, m1, m2, s1z, s2z)
 
 def _get_final_freq(approx, m1, m2, s1z, s2z):
-    """
-    Wrapper of the LALSimulation function returning the final (highest)
+    """Wrapper of the LALSimulation function returning the final (highest)
     frequency for a given approximant an template parameters
 
     Parameters
@@ -398,20 +402,25 @@ def _get_final_freq(approx, m1, m2, s1z, s2z):
     f : float
         Frequency in Hz
     """
-    # Convert to SI units for lalsimulation
-    m1kg = float(m1) * lal.MSUN_SI
-    m2kg = float(m2) * lal.MSUN_SI
-    return lalsimulation.SimInspiralGetFinalFreq(
-        m1kg, m2kg, 0, 0, float(s1z), 0, 0, float(s2z), int(approx))
+    return lalsim.SimInspiralGetFinalFreq(
+        solar_mass_to_kg(m1),
+        solar_mass_to_kg(m2),
+        0,
+        0,
+        float(s1z),
+        0,
+        0,
+        float(s2z),
+        int(approx)
+    )
 
 # vectorize to enable calls with numpy arrays
 _vec_get_final_freq = numpy.vectorize(_get_final_freq)
 
 def get_final_freq(approx, m1, m2, s1z, s2z):
-    """
-    Returns the LALSimulation function which evaluates the final
-    (highest) frequency for a given approximant using given template
-    parameters.
+    """Returns the final (highest) frequency for a given approximant using
+    given template parameters.
+
     NOTE: TaylorTx and TaylorFx are currently all given an ISCO cutoff !!
 
     Parameters
@@ -432,7 +441,14 @@ def get_final_freq(approx, m1, m2, s1z, s2z):
     f : float or numpy.array
         Frequency in Hz
     """
-    lalsim_approx = lalsimulation.GetApproximantFromString(approx)
+    # Unfortunately we need a few special cases (quite hacky in the case of
+    # IMRPhenomXAS) because some useful approximants are not understood by
+    # GetApproximantFromString().
+    if approx in ['IMRPhenomD', 'IMRPhenomXAS']:
+        return frequency_cutoff_from_name('IMRPhenomDPeak', m1, m2, s1z, s2z)
+    if approx == 'SEOBNRv5':
+        return frequency_cutoff_from_name('SEOBNRv5RD', m1, m2, s1z, s2z)
+    lalsim_approx = lalsim.GetApproximantFromString(approx)
     return _vec_get_final_freq(lalsim_approx, m1, m2, s1z, s2z)
 
 # Dictionary of functions with uniform API taking a
@@ -476,9 +492,11 @@ named_frequency_cutoffs = {
                                      p["spin1z"], p["spin2z"]),
     "SEOBNRv4Peak": lambda p: get_freq("fSEOBNRv4Peak", p["mass1"], p["mass2"],
                                        p["spin1z"], p["spin2z"]),
+    "SEOBNRv5RD": lambda p: get_freq("fSEOBNRv5RD", p["mass1"], p["mass2"],
+                                     p["spin1z"], p["spin2z"]),
     "SEOBNRv5Peak": lambda p: get_freq("fSEOBNRv5Peak", p["mass1"], p["mass2"],
                                        p["spin1z"], p["spin2z"])
-    }
+}
 
 def frequency_cutoff_from_name(name, m1, m2, s1z, s2z):
     """
@@ -511,27 +529,27 @@ def _get_imr_duration(m1, m2, s1z, s2z, f_low, approximant="SEOBNRv4"):
     m1, m2, s1z, s2z, f_low = float(m1), float(m2), float(s1z), float(s2z),\
                               float(f_low)
     if approximant == "SEOBNRv2":
-        chi = lalsimulation.SimIMRPhenomBComputeChi(m1, m2, s1z, s2z)
-        time_length = lalsimulation.SimIMRSEOBNRv2ChirpTimeSingleSpin(
+        chi = lalsim.SimIMRPhenomBComputeChi(m1, m2, s1z, s2z)
+        time_length = lalsim.SimIMRSEOBNRv2ChirpTimeSingleSpin(
                                 m1 * lal.MSUN_SI, m2 * lal.MSUN_SI, chi, f_low)
     elif approximant == 'IMRPhenomXAS':
-        time_length = lalsimulation.SimIMRPhenomXASDuration(
+        time_length = lalsim.SimIMRPhenomXASDuration(
                            m1 * lal.MSUN_SI, m2 * lal.MSUN_SI, s1z, s2z, f_low)
     elif approximant == "IMRPhenomD":
-        time_length = lalsimulation.SimIMRPhenomDChirpTime(
+        time_length = lalsim.SimIMRPhenomDChirpTime(
                            m1 * lal.MSUN_SI, m2 * lal.MSUN_SI, s1z, s2z, f_low)
     elif approximant == "SEOBNRv4":
         # NB for no clear reason this function has f_low as first argument
-        time_length = lalsimulation.SimIMRSEOBNRv4ROMTimeOfFrequency(
+        time_length = lalsim.SimIMRSEOBNRv4ROMTimeOfFrequency(
                            f_low, m1 * lal.MSUN_SI, m2 * lal.MSUN_SI, s1z, s2z)
     elif approximant == 'SEOBNRv5_ROM':
-        time_length = lalsimulation.SimIMRSEOBNRv5ROMTimeOfFrequency(
+        time_length = lalsim.SimIMRSEOBNRv5ROMTimeOfFrequency(
                            f_low, m1 * lal.MSUN_SI, m2 * lal.MSUN_SI, s1z, s2z)
     elif approximant == 'SPAtmplt' or approximant == 'TaylorF2':
-        chi = lalsimulation.SimInspiralTaylorF2ReducedSpinComputeChi(
+        chi = lalsim.SimInspiralTaylorF2ReducedSpinComputeChi(
             m1, m2, s1z, s2z
         )
-        time_length = lalsimulation.SimInspiralTaylorF2ReducedSpinChirpTime(
+        time_length = lalsim.SimInspiralTaylorF2ReducedSpinChirpTime(
             f_low, m1 * lal.MSUN_SI, m2 * lal.MSUN_SI, chi, -1
         )
     else:
@@ -568,32 +586,51 @@ def get_inspiral_tf(tc, mass1, mass2, spin1, spin2, f_low, n_points=100,
 
         # FIXME spins are not taken into account
         f_high = f_SchwarzISCO(mass1 + mass2)
-        track_f = numpy.logspace(numpy.log10(f_low), numpy.log10(f_high),
-                                 n_points)
-        track_t = numpy.array([findchirp_chirptime(float(mass1), float(mass2),
-                                        float(f), pn_2order) for f in track_f])
-    elif approximant in ['SEOBNRv2', 'SEOBNRv2_ROM_DoubleSpin',
-                         'SEOBNRv2_ROM_DoubleSpin_HI']:
-        f_high = get_final_freq('SEOBNRv2', mass1, mass2, spin1, spin2)
-        track_f = numpy.logspace(numpy.log10(f_low), numpy.log10(f_high),
-                                 n_points)
-        # use HI function as it has wider freq range validity
-        track_t = numpy.array([
-                lalsimulation.SimIMRSEOBNRv2ROMDoubleSpinHITimeOfFrequency(f,
-                    solar_mass_to_kg(mass1), solar_mass_to_kg(mass2),
-                    float(spin1), float(spin2)) for f in track_f])
-    elif approximant in ['SEOBNRv4', 'SEOBNRv4_ROM']:
-        f_high = get_final_freq('SEOBNRv4', mass1, mass2, spin1, spin2)
-        # use frequency below final freq in case of rounding error
-        track_f = numpy.logspace(numpy.log10(f_low), numpy.log10(0.999*f_high),
-                                 n_points)
-        track_t = numpy.array([
-                lalsimulation.SimIMRSEOBNRv4ROMTimeOfFrequency(
-                        f, solar_mass_to_kg(mass1), solar_mass_to_kg(mass2),
-                        float(spin1), float(spin2)) for f in track_f])
+        def tof_func(f):
+            return findchirp_chirptime(
+                float(mass1),
+                float(mass2),
+                float(f),
+                pn_2order
+            )
+    elif approximant.startswith('SEOBNRv'):
+        approximant_prefix = approximant[:len('SEOBNRv*')]
+        f_high = get_final_freq(approximant_prefix, mass1, mass2, spin1, spin2)
+        f_high *= 0.999  # avoid errors due to rounding
+        tof_func_map = {
+            # use HI function for v2 as it has wider freq range validity
+            'SEOBNRv2': lalsim.SimIMRSEOBNRv2ROMDoubleSpinHITimeOfFrequency,
+            'SEOBNRv4': lalsim.SimIMRSEOBNRv4ROMTimeOfFrequency,
+            'SEOBNRv5': lalsim.SimIMRSEOBNRv5ROMTimeOfFrequency
+        }
+        def tof_func(f):
+            return tof_func_map[approximant_prefix](
+                f,
+                solar_mass_to_kg(mass1),
+                solar_mass_to_kg(mass2),
+                float(spin1),
+                float(spin2)
+            )
+    elif approximant in ['IMRPhenomD', 'IMRPhenomXAS']:
+        f_high = get_final_freq(approximant, mass1, mass2, spin1, spin2)
+        tof_func_map = {
+            'IMRPhenomD': lalsim.SimIMRPhenomDChirpTime,
+            'IMRPhenomXAS': lalsim.SimIMRPhenomXASDuration
+        }
+        def tof_func(f):
+            return tof_func_map[approximant](
+                solar_mass_to_kg(mass1),
+                solar_mass_to_kg(mass2),
+                float(spin1),
+                float(spin2),
+                f
+            )
     else:
-        raise ValueError('Approximant ' + approximant + ' not supported')
-    return (tc - track_t, track_f)
+        raise ValueError(f'Approximant {approximant} not supported')
+    track_f = numpy.logspace(numpy.log10(f_low), numpy.log10(f_high), n_points)
+    tof_func_vec = numpy.vectorize(tof_func)
+    track_t = tc - tof_func_vec(track_f)
+    return (track_t, track_f)
 
 
 ##############################This code was taken from Andy ###########
@@ -1028,7 +1065,7 @@ def jframe_to_l0frame(mass1, mass2, f_ref, phiref=0., thetajn=0., phijl=0.,
             dimensionless spin.
     """
     inclination, spin1x, spin1y, spin1z, spin2x, spin2y, spin2z = \
-        lalsimulation.SimInspiralTransformPrecessingNewInitialConditions(
+        lalsim.SimInspiralTransformPrecessingNewInitialConditions(
             thetajn, phijl, spin1_polar, spin2_polar, spin12_deltaphi,
             spin1_a, spin2_a, mass1*lal.MSUN_SI, mass2*lal.MSUN_SI, f_ref,
             phiref)
@@ -1105,7 +1142,7 @@ def l0frame_to_jframe(mass1, mass2, f_ref, phiref=0., inclination=0.,
     # Note: unlike other LALSimulation functions, this one takes masses in
     # solar masses
     thetajn, phijl, s1pol, s2pol, s12_deltaphi, spin1_a, spin2_a = \
-        lalsimulation.SimInspiralTransformPrecessingWvf2PE(
+        lalsim.SimInspiralTransformPrecessingWvf2PE(
             inclination, spin1x, spin1y, spin1z, spin2x, spin2y, spin2z,
             mass1, mass2, f_ref, phiref)
     out = {'thetajn': thetajn,


### PR DESCRIPTION
Censor single-detector events from background_exc

The basic idea is that they should not show up in the closed box page if they are significant, so we remove them from the exclusive background if the calculated IFAR is greater than the live time of the search

This is done in a loop so that if re-calculating the fit slope affects moves an event is above this threshold, it is removed on the next pass

This PR is mainly just so I can show people before making a PR for the main repo once https://github.com/gwastro/pycbc/pull/4479 is merged (they clash a lot!)